### PR TITLE
Remove extra slashes

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,15 +109,18 @@ func (p *Proxy) ReverseProxy(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	req.URL.Scheme = target.Scheme
+	req.URL.Host = target.Host
+	req.Host = target.Host
+	req.URL.Path = target.Path
+
+	target.Path = ""
+
 	// setup a reverse proxy and forward the original request to the target
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: p.SkipSSLValidation},
 	}
-
-	req.URL.Scheme = target.Scheme
-	req.URL.Host = target.Host
-	req.Host = target.Host
 
 	proxy.ServeHTTP(rw, req)
 }


### PR DESCRIPTION
The proxying adds extra slashes at end of the path,
which, in a lot of cases, makes the URL invalid/nonexistent, i.e

".../file?guid=..."  becomes  ".../file/?guid=..."

This change fixes this issue.
It has been used in production by our customers in the past 4 months.

